### PR TITLE
Fix translation format default to text

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,6 +22,7 @@ def translate(text, from_, to):
     return requests.get(
         'https://www.googleapis.com/language/translate/v2',
         params=dict(
+            format='text',
             key=os.environ['GOOGLE_API_KEY'],
             q=text,
             source=from_, target=to


### PR DESCRIPTION
[Google Translate API’s default format](https://cloud.google.com/translate/v2/using_rest#query-params) is `html`. However, It
changes some original text to html compatible format. I fixed the
format to `text`.
